### PR TITLE
FLOW-1119 hide-scrollbar property added to f-div

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Change Log
 
+## [2.7.6] - 2024-01-16
+
+### Improvements
+
+- `f-div` : Added `hide-scrollbar` property.
+- (Note: The `hide-scrollbar` property will only hide the scrollbar; users can still scroll through the content.)
+
 ## [2.7.5] - 2024-01-11
 
 ### Improvements

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollion/flow-core",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-div/f-div-global.scss
+++ b/packages/flow-core/src/components/f-div/f-div-global.scss
@@ -121,6 +121,15 @@ f-div {
 		position: relative;
 		z-index: 1001; /* set a higher z-index for the highlighted div to place it above the overlay */
 	}
+
+	&[hide-scrollbar] {
+		-ms-overflow-style: none; /* Internet Explorer 10+ */
+		scrollbar-width: none; /* Firefox */
+
+		&::-webkit-scrollbar {
+			display: none; /* Safari and Chrome */
+		}
+	}
 	// iterating over states and appyling respective css
 	@each $state, $value in $states {
 		&[state^="#{$state}"] {

--- a/packages/flow-core/src/components/f-div/f-div.ts
+++ b/packages/flow-core/src/components/f-div/f-div.ts
@@ -220,6 +220,12 @@ export class FDiv extends FRoot {
 	highlight?: boolean = false;
 
 	/**
+	 * @attribute set true when to hide scrollbar
+	 */
+	@property({ reflect: true, type: Boolean, attribute: "hide-scrollbar" })
+	hideScrollbar?: boolean = false;
+
+	/**
 	 * @attribute Overflow property defines the behavior of the overflowing elements inside a f-div
 	 */
 	@property({ reflect: true, type: String })

--- a/packages/flow-table/CHANGELOG.md
+++ b/packages/flow-table/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Change Log
 
+## [2.2.4] - 2024-01-16
+
+### Improvements
+
+- `f-table-schema` : Added `sticky-cell-background` property.
+- (Note: Any sticky element requires a background color; therefore, sometimes adjustments to this property may be needed when used with different surface backgrounds.)
+
 ## [2.2.3] - 2023-12-14
 
 ### Bug Fixes

--- a/packages/flow-table/package.json
+++ b/packages/flow-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollion/flow-table",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Table component for flow library",
   "module": "dist/flow-table.es.js",
   "main": "dist/flow-table.cjs.js",

--- a/packages/flow-table/src/components/f-table-schema/f-table-schema.ts
+++ b/packages/flow-table/src/components/f-table-schema/f-table-schema.ts
@@ -52,6 +52,7 @@ export type FTableSchemaSize = FTableSize;
 export type FTableSchemaSelectable = FTableSelectable;
 
 export type FTableSchemaHeaderCellemplate<T = any> = (value: T) => HTMLTemplateResult;
+export type FTableSchemaStickyBackground = "default" | "secondary" | "tertiary" | "subtle";
 
 @flowElement("f-table-schema")
 export class FTableSchema extends FRoot {
@@ -127,6 +128,12 @@ export class FTableSchema extends FRoot {
 	stickyHeader = false;
 
 	/**
+	 * @attribute is sticky cell background
+	 */
+	@property({ type: String, reflect: true, attribute: "sticky-cell-background" })
+	stickyCellBackground: FTableSchemaStickyBackground = "default";
+
+	/**
 	 * filter rows based on search term
 	 */
 	@property({ type: String, reflect: true, attribute: "search-term" })
@@ -173,7 +180,7 @@ export class FTableSchema extends FRoot {
 
 	get header() {
 		return this.data?.header
-			? html`<f-trow slot="header">
+			? html`<f-trow slot="header" part="header">
 					${Object.entries(this.data.header).map(columnHeader => {
 						let width = undefined;
 						let selected = false;
@@ -191,6 +198,7 @@ export class FTableSchema extends FRoot {
 							.selected=${selected}
 							.width=${width}
 							.align=${columnHeader[1].align}
+							data-background="${this.stickyCellBackground}"
 							?sticky-left=${ifDefined(sticky)}
 							?sticky-top=${ifDefined(this.stickyHeader)}
 							@selected-column=${this.handleColumnSelection}
@@ -220,6 +228,7 @@ export class FTableSchema extends FRoot {
 					}
 				};
 				return html`<f-trow
+					part="row"
 					id=${row.id}
 					.expandIconPosition=${row.expandIconPosition ?? "right"}
 					.open=${row.open ?? false}
@@ -258,6 +267,7 @@ export class FTableSchema extends FRoot {
 							.width=${width}
 							.actions=${actions}
 							.align=${cell.align}
+							data-background="${this.stickyCellBackground}"
 							?sticky-left=${ifDefined(sticky)}
 							>${this.getCellTemplate(row.data[columnHeader[0]], highlightTerm)}
 						</f-tcell>`;

--- a/packages/flow-table/src/components/f-table/f-table-global.scss
+++ b/packages/flow-table/src/components/f-table/f-table-global.scss
@@ -67,6 +67,15 @@ f-table {
 				&[sticky-left],
 				&[sticky-top] {
 					--color-background-row: var(--color-surface-default);
+					&[data-background="secondary"] {
+						--color-background-row: var(--color-surface-secondary);
+					}
+					&[data-background="tertiary"] {
+						--color-background-row: var(--color-surface-tertiary);
+					}
+					&[data-background="subtle"] {
+						--color-background-row: var(--color-surface-subtle);
+					}
 				}
 			}
 			&:hover {
@@ -74,6 +83,15 @@ f-table {
 					&[sticky-left],
 					&[sticky-top] {
 						--color-background-row: var(--color-surface-default-hover);
+						&[data-background="secondary"] {
+							--color-background-row: var(--color-surface-secondary-hover);
+						}
+						&[data-background="tertiary"] {
+							--color-background-row: var(--color-surface-tertiary-hover);
+						}
+						&[data-background="subtle"] {
+							--color-background-row: var(--color-surface-subtle-hover);
+						}
 					}
 				}
 			}

--- a/stories/flow-core/f-div.stories.ts
+++ b/stories/flow-core/f-div.stories.ts
@@ -1,7 +1,8 @@
-import { useState } from "@storybook/client-api";
 import { html } from "lit-html";
 import { unsafeSVG } from "lit-html/directives/unsafe-svg.js";
 import FDivAnatomy from "../svg/i-fdiv-anatomy.js";
+import { createRef, ref } from "lit/directives/ref.js";
+import { FDiv } from "@ollion/flow-core";
 
 export default {
 	title: "@ollion/flow-core/f-div",
@@ -14,8 +15,8 @@ export default {
 };
 
 export const Playground = {
-	render: args => {
-		const handleClick = event => {
+	render: (args: Record<string, unknown>) => {
+		const handleClick = (event: PointerEvent) => {
 			console.log(event);
 		};
 
@@ -312,7 +313,7 @@ export const Anatomy = {
 };
 
 export const Variant = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none">
 			<f-div
 				state="subtle"
@@ -371,7 +372,7 @@ export const Variant = {
 };
 
 export const Direction = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="column">
 			<f-div width="100%" padding="large" direction="row" gap="medium" state="subtle">
 				<f-div width="hug-content" height="hug-content" padding="medium" state="secondary">
@@ -408,7 +409,7 @@ export const Direction = {
 };
 
 export const State = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="column">
 			<f-div gap="medium" padding="large" state="transparent" width="100%" height="hug-content">
 				<f-text variant="para" size="large" weight="medium">transparent state</f-text>
@@ -443,7 +444,7 @@ export const State = {
 };
 
 export const Border = {
-	render: args =>
+	render: () =>
 		html` <f-div gap="medium" padding="none" direction="column">
 			<f-div padding="medium" gap="large" width="100%" height="hug-content" state="default">
 				<f-div padding="medium" height="hug-content" border="large" state="secondary">
@@ -536,7 +537,7 @@ export const Border = {
 };
 
 export const Gap = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="column">
 			<f-div width="hug-content" height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">gap="auto"</f-text>
@@ -642,7 +643,7 @@ export const Gap = {
 };
 
 export const Padding = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="column">
 			<f-div width="hug-content" height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">padding="x-large"</f-text>
@@ -734,7 +735,7 @@ export const Padding = {
 };
 
 export const Width = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="column">
 			<f-div
 				width="fill-container"
@@ -780,7 +781,7 @@ export const Width = {
 };
 
 export const Height = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="row" height="100%">
 			<f-div
 				height="fill-container"
@@ -817,7 +818,7 @@ export const Height = {
 };
 
 export const MaxWidth = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="column">
 			<f-div
 				width="fill-container"
@@ -850,7 +851,7 @@ export const MaxWidth = {
 };
 
 export const MaxHeight = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="row" height="100%">
 			<f-div
 				height="fill-container"
@@ -881,7 +882,7 @@ export const MaxHeight = {
 };
 
 export const Tooltip = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="column">
 			<f-div width="hug-content" height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">Tooltip as a directive</f-text>
@@ -934,7 +935,7 @@ export const Tooltip = {
 };
 
 export const Overflow = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="column">
 			<f-div width="hug-content" height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">overflow="wrap"</f-text>
@@ -1042,7 +1043,7 @@ export const Overflow = {
 };
 
 export const Align = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="none" direction="column">
 			<f-div
 				width="100%"
@@ -1167,7 +1168,7 @@ export const Align = {
 };
 
 export const Sticky = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="large" direction="column">
 			<f-div width="hug-content" height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">sticky="none"</f-text>
@@ -1326,7 +1327,7 @@ export const Sticky = {
 };
 
 export const Selected = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="x-large" direction="row">
 			<f-div padding="x-large" state="subtle" width="hug-content" selected="background"
 				><f-text variant="para" size="medium" weight="regular">selected="background"</f-text>
@@ -1347,8 +1348,84 @@ export const Selected = {
 	name: "selected"
 };
 
+export const HideScrollbar = {
+	render: () =>
+		html` <f-text state="secondary"
+				>default behaviour when content overflows, it shows scrollbar</f-text
+			>
+			<f-div gap="medium" direction="column" padding="medium" height="200px" direction="row">
+				<f-text
+					>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec libero eros, ultrices eu
+					tortor ut, fermentum vehicula augue. Fusce pellentesque odio interdum eros aliquet
+					pharetra. Morbi venenatis lobortis vehicula. Mauris imperdiet hendrerit dolor ac
+					consequat. Sed venenatis tortor enim, tincidunt tristique justo dictum at. Aliquam
+					dignissim auctor odio et fermentum. Cras vitae nisi magna. Vivamus a sem molestie,
+					venenatis tortor ac, tincidunt nibh. Phasellus mi erat, euismod id pulvinar sit amet,
+					tincidunt quis eros. Pellentesque a metus elementum, posuere tortor nec, pulvinar turpis.
+					Maecenas est risus, bibendum id ornare nec, posuere eget massa. Sed finibus quis felis vel
+					imperdiet. Morbi consequat sapien sem. Integer sed eros efficitur, egestas diam ut,
+					gravida urna. Curabitur tincidunt est et convallis aliquam. Sed consectetur dui ut ligula
+					sollicitudin rhoncus. Donec luctus ut massa non tempus. Sed a euismod tortor. Suspendisse
+					nunc quam, vulputate vel scelerisque non, viverra a enim. Nam leo justo, egestas sit amet
+					metus porttitor, hendrerit dignissim felis. Aliquam et leo mollis, ultricies metus
+					gravida, blandit ipsum. Vivamus lobortis neque id luctus tincidunt. Maecenas neque felis,
+					faucibus id mi non, laoreet lacinia dui. Donec eleifend semper commodo. Aliquam erat
+					volutpat. Nunc non velit nunc. Sed accumsan pretium massa sed dignissim. Ut eu fringilla
+					justo. Quisque rhoncus dictum velit in finibus. Mauris at velit lobortis, condimentum ex
+					ac, scelerisque est. Morbi diam metus, ornare vitae rhoncus vel, maximus sit amet arcu.
+					Aliquam placerat finibus tincidunt. Phasellus sagittis odio eget lorem ullamcorper
+					dapibus. Integer massa turpis, sollicitudin et mattis nec, suscipit et turpis. Lorem ipsum
+					dolor sit amet, consectetur adipiscing elit. Mauris pretium risus eu quam gravida, vitae
+					tempus eros ullamcorper. Maecenas sed odio quis erat facilisis fermentum non ultricies
+					tellus. Sed pellentesque accumsan turpis. Morbi ut orci consequat, sodales nibh quis,
+					ultricies magna.</f-text
+				>
+			</f-div>
+			<br /><br />
+			<f-divider></f-divider>
+			<br /><br />
+			<f-text>hide-scrollbar is set (Note: Users can still scroll through the content.)</f-text>
+			<f-div
+				gap="medium"
+				direction="column"
+				hide-scrollbar
+				padding="medium"
+				height="200px"
+				direction="row"
+			>
+				<f-text
+					>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec libero eros, ultrices eu
+					tortor ut, fermentum vehicula augue. Fusce pellentesque odio interdum eros aliquet
+					pharetra. Morbi venenatis lobortis vehicula. Mauris imperdiet hendrerit dolor ac
+					consequat. Sed venenatis tortor enim, tincidunt tristique justo dictum at. Aliquam
+					dignissim auctor odio et fermentum. Cras vitae nisi magna. Vivamus a sem molestie,
+					venenatis tortor ac, tincidunt nibh. Phasellus mi erat, euismod id pulvinar sit amet,
+					tincidunt quis eros. Pellentesque a metus elementum, posuere tortor nec, pulvinar turpis.
+					Maecenas est risus, bibendum id ornare nec, posuere eget massa. Sed finibus quis felis vel
+					imperdiet. Morbi consequat sapien sem. Integer sed eros efficitur, egestas diam ut,
+					gravida urna. Curabitur tincidunt est et convallis aliquam. Sed consectetur dui ut ligula
+					sollicitudin rhoncus. Donec luctus ut massa non tempus. Sed a euismod tortor. Suspendisse
+					nunc quam, vulputate vel scelerisque non, viverra a enim. Nam leo justo, egestas sit amet
+					metus porttitor, hendrerit dignissim felis. Aliquam et leo mollis, ultricies metus
+					gravida, blandit ipsum. Vivamus lobortis neque id luctus tincidunt. Maecenas neque felis,
+					faucibus id mi non, laoreet lacinia dui. Donec eleifend semper commodo. Aliquam erat
+					volutpat. Nunc non velit nunc. Sed accumsan pretium massa sed dignissim. Ut eu fringilla
+					justo. Quisque rhoncus dictum velit in finibus. Mauris at velit lobortis, condimentum ex
+					ac, scelerisque est. Morbi diam metus, ornare vitae rhoncus vel, maximus sit amet arcu.
+					Aliquam placerat finibus tincidunt. Phasellus sagittis odio eget lorem ullamcorper
+					dapibus. Integer massa turpis, sollicitudin et mattis nec, suscipit et turpis. Lorem ipsum
+					dolor sit amet, consectetur adipiscing elit. Mauris pretium risus eu quam gravida, vitae
+					tempus eros ullamcorper. Maecenas sed odio quis erat facilisis fermentum non ultricies
+					tellus. Sed pellentesque accumsan turpis. Morbi ut orci consequat, sodales nibh quis,
+					ultricies magna.</f-text
+				>
+			</f-div>`,
+
+	name: "hide-scrollbar"
+};
+
 export const Loading = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="x-large" direction="row">
 			<f-div padding="none" direction="column" align="middle-center" gap="large">
 				<f-div padding="none" width="hug-content" align="middle-center"
@@ -1387,15 +1464,14 @@ export const Loading = {
 };
 
 export const Flags = {
-	render: args => {
-		const [highlight, setHighlight] = useState(false);
+	render: () => {
+		const highlight = false;
 
+		const highlightDiv = createRef<FDiv>();
 		const toggleHighlight = () => {
-			setHighlight(!highlight);
-
-			setTimeout(() => {
-				setHighlight(false);
-			}, 2000);
+			if (highlightDiv.value) {
+				highlightDiv.value.highlight = !highlightDiv.value.highlight;
+			}
 		};
 
 		return html`<f-div gap="medium" padding="x-large" direction="column">
@@ -1509,7 +1585,10 @@ export const Flags = {
 				></f-div>
 			</f-div>
 			<f-div padding="none" width="hug-content" align="middle-center"
-				><f-text variant="para" size="medium" weight="regular" align="center">Higlight</f-text>
+				><f-text variant="para" size="medium" weight="regular" align="center"
+					>Higlight : When the highlight is enabled, the corresponding F-div is emphasized, and the
+					remaining content is obscured by an overlay..</f-text
+				>
 			</f-div>
 			<f-button label="Highlight Toggle" @click=${toggleHighlight}></f-button>
 			<f-div
@@ -1517,8 +1596,9 @@ export const Flags = {
 				padding="large"
 				width="hug-content"
 				height="hug-content"
-				state="subtle"
+				state="secondary"
 				variant="curved"
+				${ref(highlightDiv)}
 				?highlight=${highlight}
 			>
 				<f-div

--- a/stories/flow-table/f-table-schema.stories.ts
+++ b/stories/flow-table/f-table-schema.stories.ts
@@ -48,7 +48,12 @@ export const Playground = {
 				</f-div>
 			</f-popover>
 			<f-button style="display:none" label="download" @click=${downloadFile}></f-button>
-			<f-div state="default" id="reportTemplate" overflow="scroll">
+			<f-div state="default" id="reportTemplate" direction="column" overflow="scroll">
+				<f-div state="warning" padding="large" variant="curved">
+					<f-text state="inherit"
+						>'f-table-schema' supports all properties and events of 'f-table'</f-text
+					>
+				</f-div>
 				<f-table-schema
 					.data=${args.data}
 					.highlightSelected=${args["highlight-selected"]}
@@ -63,6 +68,7 @@ export const Playground = {
 					.sortOrder=${args["sort-order"]}
 					.searchTerm=${args["search-term"]}
 					.showSearchBar=${args["show-search-bar"]}
+					.stickyCellBackground=${args["sticky-cell-background"]}
 					@next=${handleNext}
 					@toggle-row-details=${toggleRowDetails}
 					@row-input=${onRowInput}
@@ -131,6 +137,10 @@ export const Playground = {
 			control: "select",
 			options: ["desc", "desc"]
 		},
+		["sticky-cell-background"]: {
+			control: "select",
+			options: ["default", "secondary", "tertiary", "subtle"]
+		},
 
 		["search-term"]: {
 			control: {
@@ -158,7 +168,7 @@ export const Playground = {
 		["sort-order"]: "asc",
 		["search-term"]: "",
 		["show-search-bar"]: true,
-
+		["sticky-cell-background"]: "default",
 		["header-cell-template"]: (val: string) => {
 			return html`<f-div gap="small" align="middle-center">
 				<f-icon source="i-icon"></f-icon>
@@ -251,6 +261,30 @@ export const StickyHeader = {
 	},
 
 	name: "sticky-header"
+};
+
+export const StickyCellBackground = {
+	render: () => {
+		const data = getFakeUsers(30, 10);
+
+		return html`
+			<f-div gap="small" height="100%" overflow="scroll" direction="column" width="100%">
+				<f-text>
+					sticky-cell-background="secondary", this property works when variant!="stripped"</f-text
+				>
+				<f-table-schema
+					.stickyCellBackground=${"secondary"}
+					highlight-hover
+					variant="underlined"
+					.data=${data}
+					.stickyHeader=${true}
+				>
+				</f-table-schema>
+			</f-div>
+		`;
+	},
+
+	name: "sticky-cell-background"
 };
 
 export const RowsPerPage = {
@@ -531,6 +565,33 @@ export const Next = {
 	},
 
 	name: "@next"
+};
+
+export const RowClick = {
+	render: () => {
+		const data = getFakeUsers(50, 5);
+		const fieldRef = createRef();
+
+		const handleEvent = (event: CustomEvent) => {
+			if (fieldRef.value) {
+				fieldRef.value.textContent = JSON.stringify(event.detail, undefined, 2);
+			}
+		};
+
+		return html`<f-div direction="column" state="subtle" padding="small" gap="large" height="50%">
+				<f-text>'row-click' event emitted whenever user click on row</f-text>
+				<f-table-schema .data=${data} rows-per-page="20" @row-click=${handleEvent}>
+				</f-table-schema>
+				<f-divider></f-divider>
+			</f-div>
+			<br />
+			<f-divider></f-divider>
+			<br />
+			<f-text state="secondary">'event.detail' will display here</f-text>
+			<pre ${ref(fieldRef)}></pre> `;
+	},
+
+	name: "@row-click"
 };
 export const NoData = {
 	render: () => {

--- a/stories/utils/mock-users-data.ts
+++ b/stories/utils/mock-users-data.ts
@@ -83,6 +83,7 @@ export default function getFakeUsers(rowCount = 100, columnCount = 8): FTableSch
 
 		const userRow: FTableSchemaDataRow = {
 			id: faker.random.alpha(10),
+			disableSelection: i % 2 === 0,
 			expandIconPosition: "left",
 			data: { firstName, lastName, age, birthDate, email, mobile, sex, address },
 			details: function () {


### PR DESCRIPTION
### Checklist for raising a PR

- [x] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [x] Did you check the existing issues for similar queries?

### Describe your PR

# @ollion/flow-core

## [2.7.6] - 2024-01-16

### Improvements

- `f-div` : Added `hide-scrollbar` property.
- (Note: The `hide-scrollbar` property will only hide the scrollbar; users can still scroll through the content.)

# @ollion/flow-table

## [2.2.4] - 2024-01-16

### Improvements

- `f-table-schema` : Added `sticky-cell-background` property.
- (Note: Any sticky element requires a background color; therefore, sometimes adjustments to this property may be needed when used with different surface backgrounds.)
