### PR TITLE
FDS-644 f-table-schema first cell content is getting wrapped

### DIFF
--- a/packages/flow-table/CHANGELOG.md
+++ b/packages/flow-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.2.5] - 2024-02-09
+
+### Bug Fixes
+
+- `f-table-schema` : First cell content with checkbox is getting wrapped when content is large ot external template.
+
 ## [2.2.4] - 2024-01-16
 
 ### Improvements

--- a/packages/flow-table/package.json
+++ b/packages/flow-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollion/flow-table",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Table component for flow library",
   "module": "dist/flow-table.es.js",
   "main": "dist/flow-table.cjs.js",

--- a/packages/flow-table/src/components/f-tcell/f-tcell.ts
+++ b/packages/flow-table/src/components/f-tcell/f-tcell.ts
@@ -148,7 +148,8 @@ export class FTcell extends FRoot {
 								icon="i-chevron-down"
 							></f-icon-button>
 					  `
-					: nothing}<slot></slot>
+					: nothing}
+				<f-div><slot></slot></f-div>
 			</f-div>
 			<f-div
 				class="details-toggle"

--- a/stories/utils/mock-users-data.ts
+++ b/stories/utils/mock-users-data.ts
@@ -21,7 +21,16 @@ export default function getFakeUsers(rowCount = 100, columnCount = 8): FTableSch
 	for (let i = 0; i < rowCount; i++) {
 		const firstName: FTableSchemaCell<string> = {
 			value: faker.person.firstName(),
-			align: "middle-left"
+			align: "middle-left",
+			template: function () {
+				return html`<f-div gap="small" align="middle-left" width="100%" height="100%">
+					<f-pictogram .source=${faker.internet.emoji()}></f-pictogram>
+					<f-div direction="column" height="hug-content">
+						<f-text>${this.value}</f-text>
+						<f-text size="small" state="secondary">${faker.person.jobTitle()}</f-text>
+					</f-div>
+				</f-div>`;
+			}
 		};
 		const lastName = {
 			value: faker.person.lastName(),
@@ -88,7 +97,7 @@ export default function getFakeUsers(rowCount = 100, columnCount = 8): FTableSch
 		const userRow: FTableSchemaDataRow = {
 			id: getId(),
 			disableSelection: i % 2 === 0,
-			expandIconPosition: "left",
+			expandIconPosition: "right",
 			data: { firstName, lastName, age, birthDate, email, mobile, sex, address },
 			details: function () {
 				return html`<f-div padding="large"


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

# @ollion/flow-table

## [2.2.5] - 2024-02-09

### Bug Fixes

- `f-table-schema` : First cell content with checkbox is getting wrapped when content is large ot external template.

Before

![Screenshot 2024-02-08 at 7 26 57 PM](https://github.com/ollionorg/flow-core/assets/67629551/e585b7e8-fe70-4607-88da-f56d86bc4e17)

After 

<img width="702" alt="Screenshot 2024-02-09 at 12 20 08 PM" src="https://github.com/ollionorg/flow-core/assets/67629551/536d376e-3f82-4d8a-bfe2-ee251c943e05">
