### PR TITLE
FDS-651 The use-virtualizer option has been added to f-select to control its usage.

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.8.7] - 2024-02-22
+
+### Improvements
+
+- The `f-select` virtualizer has been made optional and can be controlled using the `use-virtualizer` flag. This change will resolve the Cypress test case failure issue.
+
 ## [2.8.6] - 2024-02-22
 
 ### Bug Fixes

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollion/flow-core",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-select/f-select.test.ts
+++ b/packages/flow-core/src/components/f-select/f-select.test.ts
@@ -4,7 +4,7 @@ import IconPack from "@ollion/flow-system-icon/dist/types/icon-pack";
 // import flow-core elements
 import "@ollion/flow-core";
 
-import { FIcon, ConfigUtil, FSelect, FText, FTag } from "@ollion/flow-core";
+import { FIcon, ConfigUtil, FSelect, FText, FTag, FCheckbox } from "@ollion/flow-core";
 // setting icon pack for testing icon related test cases
 ConfigUtil.setConfig({ iconPack: IconPack });
 
@@ -73,6 +73,20 @@ describe("f-select", () => {
 		const descendant = el.shadowRoot!.querySelector(".f-select-searchable")!;
 		const input = descendant.children[1];
 		expect(input.tagName.toLowerCase()).to.equal("input");
+	});
+
+	it("options menu should render with checkboxes when checkbox is true", async () => {
+		const el = await fixture(html`
+			<f-select
+				.options=${["option 1"]}
+				.value=${["option 1"]}
+				type="multiple"
+				?checkbox=${true}
+			></f-select>
+		`);
+		const descendant = el.shadowRoot!.querySelector(".f-select-options-clickable")!;
+		const checkbox = descendant.children[0];
+		expect(checkbox).instanceOf(FCheckbox);
 	});
 
 	it("render with 'view more' button if limit is less than selected-options", async () => {

--- a/packages/flow-core/src/components/f-select/f-select.ts
+++ b/packages/flow-core/src/components/f-select/f-select.ts
@@ -279,6 +279,16 @@ export class FSelect extends FRoot {
 	maxOptionsWidth?: FSelectMaxOptionsWidth;
 
 	/**
+	 * @attribute use virtulizer for options (set true if you have 1k+ options)
+	 */
+	@property({ reflect: true, type: Boolean, attribute: "use-virtualizer" })
+	useVirtualizer?: boolean;
+
+	set ["use-virtualizer"](value: boolean | undefined) {
+		this.useVirtualizer = value;
+	}
+
+	/**
 	 * icon size
 	 */
 	get iconSize() {

--- a/packages/flow-core/src/components/f-select/render.ts
+++ b/packages/flow-core/src/components/f-select/render.ts
@@ -10,6 +10,7 @@ import { html, nothing } from "lit";
 import { classMap } from "lit-html/directives/class-map.js";
 import { unsafeSVG } from "lit-html/directives/unsafe-svg.js";
 import loader from "../../mixins/svg/loader";
+import { map } from "lit/directives/map.js";
 import "@lit-labs/virtualizer";
 
 export default function render(this: FSelect) {
@@ -364,63 +365,68 @@ export default function render(this: FSelect) {
 }
 
 export function renderArrayOptions(this: FSelect) {
-	return html` <lit-virtualizer
-		.items=${this.filteredOptions as FSelectArray}
-		.keyFunction=${(option: FSelectSingleOption, idx: number) => {
-			if (typeof option === "string") {
-				return `${idx}${option}`;
-			}
-			return idx + this.getOptionQaId(option);
-		}}
-		.renderItem=${(option: FSelectSingleOption) =>
-			html`<f-div
-				class="f-select-options-clickable"
-				padding="medium"
-				data-qa-option=${this.getOptionQaId(option)}
-				height="hug-content"
-				width="fill-container"
-				direction="row"
-				align="middle-left"
-				gap="small"
-				.selected=${this.isSelected(option) ? "background" : undefined}
-				@click=${(e: MouseEvent) => {
-					this.handleOptionSelection(option, e);
-				}}
-				@mouseover=${(e: MouseEvent) => {
-					this.handleOptionMouseOver(e);
-				}}
-				.disabled=${typeof option === "object" && option.disabled}
-			>
-				${this.checkbox
-					? html` <f-checkbox
-							state=${this.state}
-							size=${this.size}
-							value=${this.isSelected(option) ? "checked" : "unchecked"}
-							@input=${(e: MouseEvent) => {
-								this.handleCheckboxInput(option, e);
-							}}
-					  ></f-checkbox>`
-					: nothing}
-				${(option as FSelectOptionObject)?.icon && !this.optionTemplate
-					? html` <f-div padding="none" gap="none" height="hug-content" width="hug-content"
-							><f-icon size="medium" source=${(option as FSelectOptionObject)?.icon}></f-icon
-					  ></f-div>`
-					: nothing}
-				${this.optionTemplate ? this.optionTemplate(option) : nothing}
-				${!this.optionTemplate
-					? html` <f-div padding="none" gap="none" height="hug-content" width="fill-container"
-							><f-text variant="para" size="small" weight="regular"
-								>${(option as FSelectOptionObject)?.title ?? option}</f-text
-							></f-div
-					  >`
-					: nothing}
-				${this.isSelected(option) && !this.checkbox
-					? html` <f-div padding="none" gap="none" height="hug-content" width="hug-content"
-							><f-icon size="small" source="i-tick"></f-icon
-					  ></f-div>`
-					: nothing}
-			</f-div>`}
-	></lit-virtualizer>`;
+	const optionHtml = (option: FSelectSingleOption) =>
+		html`<f-div
+			class="f-select-options-clickable"
+			padding="medium"
+			data-qa-option=${this.getOptionQaId(option)}
+			height="hug-content"
+			width="fill-container"
+			direction="row"
+			align="middle-left"
+			gap="small"
+			.selected=${this.isSelected(option) ? "background" : undefined}
+			@click=${(e: MouseEvent) => {
+				this.handleOptionSelection(option, e);
+			}}
+			@mouseover=${(e: MouseEvent) => {
+				this.handleOptionMouseOver(e);
+			}}
+			.disabled=${typeof option === "object" && option.disabled}
+		>
+			${this.checkbox
+				? html` <f-checkbox
+						state=${this.state}
+						size=${this.size}
+						value=${this.isSelected(option) ? "checked" : "unchecked"}
+						@input=${(e: MouseEvent) => {
+							this.handleCheckboxInput(option, e);
+						}}
+				  ></f-checkbox>`
+				: nothing}
+			${(option as FSelectOptionObject)?.icon && !this.optionTemplate
+				? html` <f-div padding="none" gap="none" height="hug-content" width="hug-content"
+						><f-icon size="medium" source=${(option as FSelectOptionObject)?.icon}></f-icon
+				  ></f-div>`
+				: nothing}
+			${this.optionTemplate ? this.optionTemplate(option) : nothing}
+			${!this.optionTemplate
+				? html` <f-div padding="none" gap="none" height="hug-content" width="fill-container"
+						><f-text variant="para" size="small" weight="regular"
+							>${(option as FSelectOptionObject)?.title ?? option}</f-text
+						></f-div
+				  >`
+				: nothing}
+			${this.isSelected(option) && !this.checkbox
+				? html` <f-div padding="none" gap="none" height="hug-content" width="hug-content"
+						><f-icon size="small" source="i-tick"></f-icon
+				  ></f-div>`
+				: nothing}
+		</f-div>`;
+
+	if (this.useVirtualizer) {
+		return html` <lit-virtualizer
+			.items=${this.filteredOptions as FSelectArray}
+			.keyFunction=${(option: FSelectSingleOption, idx: number) => {
+				if (typeof option === "string") {
+					return `${idx}${option}`;
+				}
+				return idx + this.getOptionQaId(option);
+			}}
+			.renderItem=${optionHtml}
+		></lit-virtualizer>`;
+	}
+	return map(this.filteredOptions as FSelectArray, optionHtml);
 }
 
 export function renderGroupOptions(this: FSelect) {

--- a/packages/flow-form-builder/CHANGELOG.md
+++ b/packages/flow-form-builder/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.2.5] - 2024-02-13
+
+### Patch Changes
+
+- The `useVirtualizer` property has been added to the `select` field to enable smooth search and selection for a large number of options.
+
 ## [2.2.4] - 2024-02-13
 
 ### Patch Changes

--- a/packages/flow-form-builder/package.json
+++ b/packages/flow-form-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollion/flow-form-builder",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Form builder for the flow design system",
   "module": "dist/flow-form-builder.es.js",
   "main": "dist/flow-form-builder.cjs.js",

--- a/packages/flow-form-builder/src/components/f-form-builder/fields/select.ts
+++ b/packages/flow-form-builder/src/components/f-form-builder/fields/select.ts
@@ -26,6 +26,7 @@ export default function (
 			.clear=${ifDefined(field.clear)}
 			.width=${field.width}
 			.maxOptionsWidth=${field.maxOptionsWidth}
+			.useVirtualizer=${field.useVirtualizer}
 			data-qa-element-id=${field.qaId || field.id}
 			height=${ifDefined(field.height)}
 			?disabled=${field.disabled}

--- a/packages/flow-form-builder/src/types.ts
+++ b/packages/flow-form-builder/src/types.ts
@@ -205,6 +205,7 @@ export type FormBuilderSelectField = FormBuilderBaseField & {
 	selectionLimit?: number;
 	createOption?: boolean;
 	loading?: boolean;
+	useVirtualizer?: boolean;
 };
 
 // text-area type field

--- a/stories/flow-core/f-select.mdx
+++ b/stories/flow-core/f-select.mdx
@@ -419,6 +419,19 @@ limits the no. of tags to be displayed on option selection.
 
 <br />
 
+## use-virtualizer
+
+For a large number of options, utilize the 'use-virtualizer' option to ensure smooth
+searching and selection.
+
+<Canvas>
+	<Story of={FSelectStories.UseVirtualizer} />
+</Canvas>
+
+<ArgsTable of={"f-select"} />
+
+<br />
+
 # Flags
 
 <f-divider />

--- a/stories/flow-core/f-select.stories.ts
+++ b/stories/flow-core/f-select.stories.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { FSelectOptionObject, FSelectSingleOption } from "@ollion/flow-core";
+import { FSelectOptionObject } from "@ollion/flow-core";
 import { html } from "lit-html";
 import { unsafeSVG } from "lit-html/directives/unsafe-svg.js";
 import fSelectAnatomy from "../svg/i-fselect-anatomy.js";
@@ -10,6 +10,12 @@ export default {
 	parameters: {
 		controls: {
 			hideNoControlsWarning: true
+		},
+		docs: {
+			story: {
+				inline: false,
+				height: "300px"
+			}
 		}
 	}
 };
@@ -63,6 +69,7 @@ export const Playground = {
 						icon-left=${args["icon-left"]}
 						.size=${args.size}
 						?auto-add-option=${args["auto-add-option"]}
+						.useVirtualizer=${args["use-virtualizer"]}
 						@add-option=${handleCreateOption}
 						@search-input=${handleSearchInput}
 					>
@@ -177,6 +184,9 @@ export const Playground = {
 				arg: "create-option",
 				eq: true
 			}
+		},
+		["use-virtualizer"]: {
+			control: "boolean"
 		}
 	},
 
@@ -211,7 +221,8 @@ export const Playground = {
 		checkbox: false,
 		["selection-limit"]: 2,
 		["create-option"]: false,
-		["auto-add-option"]: true
+		["auto-add-option"]: true,
+		["use-virtualizer"]: false
 	}
 };
 
@@ -1530,4 +1541,39 @@ export const AutoAddOption = {
 	},
 
 	name: "auto-add-option"
+};
+
+export const UseVirtualizer = {
+	render: () => {
+		const value = "";
+		const options: string[] = [];
+		for (let o = 0; o < 3000; o++) {
+			options.push(
+				`${o + 1} ${faker.location.city()} ${faker.location.country()} ${faker.location.zipCode()}`
+			);
+		}
+
+		const handleValue = (e: CustomEvent) => {
+			console.log("input event", e);
+		};
+
+		return html`
+			<f-select
+				placeholder="Select City"
+				@input=${handleValue}
+				.options=${options}
+				.value=${value}
+				use-virtualizer
+				?searchable=${true}
+			>
+				<f-div slot="label" padding="none" gap="none">3k options</f-div>
+				<f-div slot="help" padding="none" gap="none"
+					>For a large number of options, utilize the 'use-virtualizer' option to ensure smooth
+					searching and selection.</f-div
+				>
+			</f-select>
+		`;
+	},
+
+	name: "use-virtualizer"
 };


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

# @ollion/flow-core

## [2.8.7] - 2024-02-22

### Improvements

- The `f-select` virtualizer has been made optional and can be controlled using the `use-virtualizer` flag. This change will resolve the Cypress test case failure issue.

# @ollion/flow-form-builder

## [2.2.5] - 2024-02-13

### Patch Changes

- The `useVirtualizer` property has been added to the `select` field to enable smooth search and selection for a large number of options.
