### PR TITLE
Externalize lodash-es to reduce bundle size

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.9.1] - 2024-03-10
+
+### Improvements
+
+- Externalise `@emoji-mart/data` and `lodash-es` to reduce bundle size.
+
 ## [2.9.0] - 2024-03-01
 
 ### Features

--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Improvements
 
-- Externalise `@emoji-mart/data` and `lodash-es` to reduce bundle size.
+- Externalise `lodash-es` to reduce bundle size.
 
 ## [2.9.0] - 2024-03-01
 

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollion/flow-core",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/vite.config.ts
+++ b/packages/flow-core/vite.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
 			external: [
 				"axios",
 				"emoji-mart",
+				"@emoji-mart/data",
+				"lodash-es",
 				/^lit/,
 				"rxjs",
 				"@ollion/flow-core-config",

--- a/packages/flow-core/vite.config.ts
+++ b/packages/flow-core/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
 			external: [
 				"axios",
 				"emoji-mart",
-				"@emoji-mart/data",
 				"lodash-es",
 				/^lit/,
 				"rxjs",


### PR DESCRIPTION
- We do need to consider how to lazily load the emoji mart code in future because this still doesn't fix the fact that the final client bundler will end up bundling everything together in the Flow bundle
- Same goes for other bigger libraries

### Checklist for raising a PR

- [x] Gone through UX documnetation for adding new features.
- [x] All necessary unit tests covered.
- [x] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [x] Did you check the contributing doc?
- [x] Did you check the existing issues for similar queries?

### Describe your PR

### Add additional question here

- [ ] `Yes`
- [ ] `No`
- [ ] `NA`
