### PR TITLE
FDS-661 category propetry added to f-tag

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Improvements
 
-- - Added `category` property to `f-tag` to support both `fill` and `outline` values. Default value set to `fill`.
+- Added `category` property to `f-tag` to support both `fill` and `outline` values. Default value set to `fill`.
+- Added `max-width` property to `f-tag`.
 
 ## [2.9.6] - 2024-03-28
 

--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.9.7] - 2024-03-28
+
+### Improvements
+
+- - Added `category` property to `f-tag` to support both `fill` and `outline` values. Default value set to `fill`.
+
 ## [2.9.6] - 2024-03-28
 
 ### Improvements

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollion/flow-core",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-counter/f-counter.ts
+++ b/packages/flow-core/src/components/f-counter/f-counter.ts
@@ -12,6 +12,7 @@ import { validateHTMLColor } from "validate-color";
 import { validateHTMLColorName } from "validate-color";
 import { flowElement } from "./../../utils";
 import { injectCss } from "@ollion/flow-core-config";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 injectCss("f-counter", globalStyle);
 
@@ -190,9 +191,9 @@ export class FCounter extends FRoot {
 		return html`<div
 			class=${classMap(classes)}
 			style=${this.applyStyles()}
-			size=${this.size}
-			state=${this.state}
-			category=${this.category}
+			size=${ifDefined(this.size)}
+			state=${ifDefined(this.state)}
+			category=${ifDefined(this.category)}
 			?loading=${this.loading}
 			?disabled=${this.disabled}
 		>

--- a/packages/flow-core/src/components/f-tag/f-tag.scss
+++ b/packages/flow-core/src/components/f-tag/f-tag.scss
@@ -111,7 +111,7 @@ in this case it is `f-tag`
 		}
 
 		@each $state, $color in $states {
-			&[state="#{$state}"] {
+			&[state="#{$state}"][category="fill"] {
 				background-color: map.get($color, "background") !important;
 				border: 1px
 					solid
@@ -135,6 +135,34 @@ in this case it is `f-tag`
 					cursor: pointer;
 					&:hover {
 						background-color: map.get($color, "hover") !important;
+					}
+				}
+			}
+			&[state="#{$state}"][category="outline"] {
+				background-color: transparent !important;
+				color: map.get($color, "background");
+				border: 1px
+					solid
+					map.get($color, "background") !important; // added to match width of outline category
+				// hover changes background
+				&[selected] {
+					background-color: transparent !important;
+					border: 1px solid map.get($color, "selected") !important;
+				}
+				// if loading attribute specified then change background, border, color and svg
+				&[loading] {
+					background-color: transparent !important;
+					border: 1px solid map.get($color, "loading") !important;
+					color: transparent !important;
+					svg path.loader-fill {
+						fill: map.get($color, "background") !important;
+					}
+				}
+				// adding clickable behavior
+				&[clickable]:not([selected]) {
+					cursor: pointer;
+					&:hover {
+						border: 1px solid map.get($color, "hover") !important;
 					}
 				}
 			}

--- a/packages/flow-core/src/components/f-tag/f-tag.scss
+++ b/packages/flow-core/src/components/f-tag/f-tag.scss
@@ -90,7 +90,6 @@ in this case it is `f-tag`
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
-			max-width: 240px;
 		}
 
 		// class to appply shimmer . This class is applied through javascript please check f-tag.ts

--- a/packages/flow-core/src/components/f-tag/f-tag.ts
+++ b/packages/flow-core/src/components/f-tag/f-tag.ts
@@ -125,6 +125,12 @@ export class FTag extends FRoot {
 	@property({ type: Boolean })
 	clickable?: boolean = false;
 
+	/**
+	 * @attribute is clickable
+	 */
+	@property({ type: String, reflect: true, attribute: "max-width" })
+	maxWidth: string = "240px";
+
 	labelDiv: Ref<FDiv> = createRef();
 
 	/**
@@ -365,7 +371,9 @@ export class FTag extends FRoot {
 				?clickable=${this.clickable}
 			>
 				${iconLeft}
-				<f-div class="text-content" ${ref(this.labelDiv)}>${this.label}</f-div>
+				<f-div class="text-content" style="max-width:${this.maxWidth}" ${ref(this.labelDiv)}
+					>${this.label}</f-div
+				>
 				${counter}${iconRight}
 			</div>`
 		);

--- a/stories/flow-core/f-tag.stories.ts
+++ b/stories/flow-core/f-tag.stories.ts
@@ -14,21 +14,20 @@ export default {
 
 export const Playground = {
 	render: (args: Record<string, string>) =>
-		html` <f-div padding="large" width="150px">
-			<f-tag
-				.label=${args.label}
-				.category=${args.category}
-				.size=${args.size}
-				.state=${args.state}
-				icon-left=${args["icon-left"]}
-				icon-right=${args["icon-right"]}
-				.counter=${args.counter}
-				.loading=${args.loading}
-				.disabled=${args.disabled}
-				.selected=${args.selected}
-				?clickable=${args.clickable}
-			></f-tag
-		></f-div>`,
+		html` <f-tag
+			.label=${args.label}
+			.category=${args.category}
+			.size=${args.size}
+			.state=${args.state}
+			icon-left=${args["icon-left"]}
+			max-width=${args["max-width"]}
+			icon-right=${args["icon-right"]}
+			.counter=${args.counter}
+			.loading=${args.loading}
+			.disabled=${args.disabled}
+			.selected=${args.selected}
+			?clickable=${args.clickable}
+		></f-tag>`,
 
 	name: "Playground",
 
@@ -68,7 +67,9 @@ export const Playground = {
 		["icon-left"]: {
 			control: "text"
 		},
-
+		["max-width"]: {
+			control: "text"
+		},
 		["icon-right"]: {
 			control: "text"
 		},
@@ -112,10 +113,11 @@ export const Playground = {
 	},
 
 	args: {
-		label: "labelsdjkhfsjhgmndf sdfgjdf sgdfhsd dghgfjhsdgfgjsdfnmsgdfjhgsdjfjsdgfhegfjehwgjfgwegj",
+		label: "Lorem Ipsum is simply dummy text of the printing and typesetting",
 		size: "medium",
 		category: "fill",
 		state: "neutral",
+		["max-width"]: "240px",
 		["icon-left"]: undefined,
 		["icon-right"]: undefined,
 		counter: undefined,
@@ -199,6 +201,23 @@ export const IconRight = {
 		</f-div>`,
 
 	name: "icon-right"
+};
+
+export const MaxWidth = {
+	render: () =>
+		html`<f-div gap="large" padding="x-large" direction="column" align="middle-left">
+			<f-tag label="max-width:100px" max-width="100px" state="neutral"></f-tag>
+			<f-tag
+				label="max-width:200px;Testing lengthy text will get ellipsis"
+				max-width="200px"
+			></f-tag>
+			<f-tag
+				label="max-width:300px;Testing lengthy text will get ellipsis"
+				max-width="300px"
+			></f-tag>
+		</f-div>`,
+
+	name: "max-width"
 };
 
 export const Counter = {

--- a/stories/flow-core/f-tag.stories.ts
+++ b/stories/flow-core/f-tag.stories.ts
@@ -13,10 +13,11 @@ export default {
 };
 
 export const Playground = {
-	render: args =>
+	render: (args: Record<string, string>) =>
 		html` <f-div padding="large" width="150px">
 			<f-tag
 				.label=${args.label}
+				.category=${args.category}
 				.size=${args.size}
 				.state=${args.state}
 				icon-left=${args["icon-left"]}
@@ -39,6 +40,10 @@ export const Playground = {
 		size: {
 			control: "select",
 			options: ["large", "medium", "small"]
+		},
+		category: {
+			control: "select",
+			options: ["fill", "outline"]
 		},
 
 		state: {
@@ -109,6 +114,7 @@ export const Playground = {
 	args: {
 		label: "labelsdjkhfsjhgmndf sdfgjdf sgdfhsd dghgfjhsdgfgjsdfnmsgdfjhgsdjfjsdgfhegfjehwgjfgwegj",
 		size: "medium",
+		category: "fill",
 		state: "neutral",
 		["icon-left"]: undefined,
 		["icon-right"]: undefined,
@@ -126,7 +132,7 @@ export const Anatomy = {
 };
 
 export const Size = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="x-large" padding="x-large" align="middle-center">
 			<f-tag size="large" label="Large" state="neutral"></f-tag>
 			<f-tag size="medium" label="Medium" state="neutral"></f-tag>
@@ -137,7 +143,7 @@ export const Size = {
 };
 
 export const State = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="x-large" padding="x-large" align="middle-center" state="primary">
 			<f-tag size="medium" label="Neutral" state="neutral"></f-tag>
 			<f-tag size="medium" label="Primary" state="primary"></f-tag>
@@ -150,9 +156,18 @@ export const State = {
 
 	name: "state"
 };
+export const Category = {
+	render: () =>
+		html`<f-div gap="x-large" padding="x-large" align="middle-center">
+			<f-tag size="medium" category="fill" label="Fill" state="neutral"></f-tag>
+			<f-tag size="medium" category="outline" label="outline" state="neutral"></f-tag>
+		</f-div>`,
+
+	name: "category"
+};
 
 export const Label = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="large" padding="x-large" direction="row" align="middle-center">
 			<f-tag label="Label" state="neutral"></f-tag>
 			<f-tag state="neutral" icon-left="i-star"></f-tag>
@@ -162,7 +177,7 @@ export const Label = {
 };
 
 export const IconLeft = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="large" padding="x-large" align="middle-center" direction="row">
 			<f-tag label="icon left" icon-left="i-star" state="neutral"></f-tag>
 			<f-tag icon-left="i-star" state="neutral"></f-tag>
@@ -172,7 +187,7 @@ export const IconLeft = {
 };
 
 export const IconRight = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="large" padding="x-large" direction="row" align="middle-center">
 			<f-tag label="icon right" icon-right="i-star" state="neutral"></f-tag>
 			<f-tag
@@ -187,7 +202,7 @@ export const IconRight = {
 };
 
 export const Counter = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="large" padding="x-large" direction="row" align="middle-center">
 			<f-tag label="Label" state="neutral" counter="88"></f-tag>
 			<f-tag label="Label" state="neutral" icon-left="i-star" counter="88"></f-tag>
@@ -199,43 +214,43 @@ export const Counter = {
 };
 
 export const Flags = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="large" padding="x-large" direction="column">
 			<f-div height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">Loading</f-text>
 			</f-div>
 			<f-div padding="none" direction="row" gap="x-large">
 				<f-tag state="neutral" label="label"></f-tag>
-				<f-tag state="neutral" label="label" loading=${true}></f-tag>
+				<f-tag state="neutral" label="label" .loading=${true}></f-tag>
 			</f-div>
 			<f-div padding="none" direction="row" gap="x-large">
 				<f-tag state="neutral" label="label" icon-left="i-plus"></f-tag>
-				<f-tag state="neutral" label="label" loading=${true} icon-left="i-plus"></f-tag>
+				<f-tag state="neutral" label="label" .loading=${true} icon-left="i-plus"></f-tag>
 			</f-div>
 			<f-div padding="none" direction="row" gap="x-large">
 				<f-tag state="neutral" label="label" icon-right="i-plus"></f-tag>
-				<f-tag state="neutral" label="label" loading=${true} icon-right="i-plus"></f-tag>
+				<f-tag state="neutral" label="label" .loading=${true} icon-right="i-plus"></f-tag>
 			</f-div>
 			<f-div height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">Disabled</f-text>
 			</f-div>
 			<f-div padding="none" direction="row" gap="x-large">
 				<f-tag state="neutral" label="label"></f-tag>
-				<f-tag state="neutral" label="label" disabled=${true}></f-tag>
+				<f-tag state="neutral" label="label" .disabled=${true}></f-tag>
 			</f-div>
 			<f-div height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">Clickable</f-text>
 			</f-div>
 			<f-div padding="none" direction="row" gap="x-large">
 				<f-tag state="neutral" label="label"></f-tag>
-				<f-tag state="neutral" label="label" clickable=${true}></f-tag>
+				<f-tag state="neutral" label="label" .clickable=${true}></f-tag>
 			</f-div>
 			<f-div height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">Selected</f-text>
 			</f-div>
 			<f-div padding="none" direction="row" gap="x-large">
 				<f-tag state="neutral" label="label"></f-tag>
-				<f-tag state="neutral" label="label" selected=${true}></f-tag>
+				<f-tag state="neutral" label="label" .selected=${true}></f-tag>
 			</f-div>
 		</f-div>`,
 


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

# @ollion/flow-core

## [2.9.7] - 2024-03-28

### Improvements

- - Added `category` property to `f-tag` to support both `fill` and `outline` values. Default value set to `fill`.
<img width="963" alt="Screenshot 2024-03-28 at 4 19 11 PM" src="https://github.com/ollionorg/flow-core/assets/67629551/8844f3f2-0083-47eb-83b7-bf35e9e98cea">


