### PR TITLE
FDS-668 optionsMaxHeight added in suggest field of f-form-builder

### DIFF
--- a/packages/flow-form-builder/CHANGELOG.md
+++ b/packages/flow-form-builder/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.4.2] - 2024-05-15
+
+### Patch Changes
+
+- `optionsMaxHeight` property added for suggest field.
+
 ## [2.4.1] - 2024-04-22
 
 ### Bug Fixes

--- a/packages/flow-form-builder/package.json
+++ b/packages/flow-form-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ollion/flow-form-builder",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Form builder for the flow design system",
   "module": "dist/flow-form-builder.es.js",
   "main": "dist/flow-form-builder.cjs.js",

--- a/packages/flow-form-builder/src/components/f-form-builder/fields/suggest.ts
+++ b/packages/flow-form-builder/src/components/f-form-builder/fields/suggest.ts
@@ -30,6 +30,7 @@ export default function (
 			.suffixWhen=${field.suffixWhen}
 			.suggestWhen=${ifDefined(field.suggestWhen)}
 			max-length=${ifDefined(field.maxLength)}
+			.optionsMaxHeight=${field.optionsMaxHeight}
 			?loading=${field.loading ?? false}
 			?disabled=${field.disabled ?? false}
 			?clear=${field.clear ?? true}

--- a/packages/flow-form-builder/src/types.ts
+++ b/packages/flow-form-builder/src/types.ts
@@ -154,6 +154,7 @@ export type FormBuilderSuggestField = FormBuilderBaseField & {
 	loading?: boolean;
 	readonly?: boolean;
 	clear?: boolean;
+	optionsMaxHeight?: string;
 	suggestions?: FSuggestSuggestions;
 	suffixWhen?: FormBuilderSuffixCondition;
 	suggestWhen?: FSuggestWhen;

--- a/stories/flow-form-builder/f-formbuilder-field.ts
+++ b/stories/flow-form-builder/f-formbuilder-field.ts
@@ -429,6 +429,7 @@ const field: FormBuilderField = {
 				title: "Click inside field to see suggestions",
 				description: "Select suggestion to fill value"
 			},
+			optionsMaxHeight: "100px",
 			suggestWhen: () => true,
 			suggestions: [
 				"Suggestion 1",


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

# @ollion/flow-form-uilder

## [2.4.2] - 2024-05-15

### Patch Changes

- `optionsMaxHeight` property added for suggest field.
